### PR TITLE
Shared preferences

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
 
 
     <application
+        android:name=".common.MyApp"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:networkSecurityConfig="@xml/network_security_config"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -54,11 +54,6 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
         <activity
             android:name=".ui.updatePassword.UpdatePasswordActivity"

--- a/app/src/main/java/com/offhome/app/MainActivity.kt
+++ b/app/src/main/java/com/offhome/app/MainActivity.kt
@@ -9,6 +9,8 @@ import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.offhome.app.common.Constants
+import com.offhome.app.common.SharedPreferenceManager
 import com.offhome.app.ui.createactivity.CreateActivity
 
 class MainActivity : AppCompatActivity() {
@@ -23,7 +25,10 @@ class MainActivity : AppCompatActivity() {
         // menu should be considered as top level destinations.
         val appBarConfiguration = AppBarConfiguration(
             setOf(
-                R.id.navigation_activities, R.id.navigation_explore, R.id.navigation_chats, R.id.navigation_profile
+                R.id.navigation_activities,
+                R.id.navigation_explore,
+                R.id.navigation_chats,
+                R.id.navigation_profile
             )
         )
 

--- a/app/src/main/java/com/offhome/app/common/Constants.kt
+++ b/app/src/main/java/com/offhome/app/common/Constants.kt
@@ -1,0 +1,9 @@
+package com.offhome.app.common
+
+data class Constants(
+    val BASE_URL: String = "http://ec2-100-25-149-77.compute-1.amazonaws.com:3000/",
+
+    // Preferences
+    val PREF_EMAIL: String = "PREF_EMAIL",
+    val PREF_PROVIDER: String = "PREF_PROVIDER"
+)

--- a/app/src/main/java/com/offhome/app/common/Constants.kt
+++ b/app/src/main/java/com/offhome/app/common/Constants.kt
@@ -5,5 +5,7 @@ data class Constants(
 
     // Preferences
     val PREF_EMAIL: String = "PREF_EMAIL",
-    val PREF_PROVIDER: String = "PREF_PROVIDER"
+    val PREF_PROVIDER: String = "PREF_PROVIDER",
+    val PREF_PROVIDER_PASSWORD: String = "PASSWORD",
+    val PREF_PROVIDER_GOOGLE: String = "GOOGLE"
 )

--- a/app/src/main/java/com/offhome/app/common/MyApp.kt
+++ b/app/src/main/java/com/offhome/app/common/MyApp.kt
@@ -1,0 +1,18 @@
+package com.offhome.app.common
+
+import android.app.Application
+import android.content.Context
+
+class MyApp: Application() {
+
+    override fun onCreate() {
+        instanceApp = this
+        super.onCreate()
+    }
+
+    companion object Factory {
+        private lateinit var instanceApp: MyApp
+        fun getInstance(): MyApp = instanceApp
+        fun getContext(): Context = instanceApp
+    }
+}

--- a/app/src/main/java/com/offhome/app/common/SharedPreferenceManager.kt
+++ b/app/src/main/java/com/offhome/app/common/SharedPreferenceManager.kt
@@ -23,8 +23,8 @@ class SharedPreferenceManager {
             editor.putBoolean(dataLabel, dataValue)
             editor.apply()
         }
-        fun getStringValue(dataLabel: String): String {
-            return getSharedPreferences().getString(dataLabel, null).toString()
+        fun getStringValue(dataLabel: String): String? {
+            return getSharedPreferences().getString(dataLabel, null)
         }
         fun getBooleanValue(dataLabel: String): Boolean {
             return getSharedPreferences().getBoolean(dataLabel, false)

--- a/app/src/main/java/com/offhome/app/common/SharedPreferenceManager.kt
+++ b/app/src/main/java/com/offhome/app/common/SharedPreferenceManager.kt
@@ -1,0 +1,33 @@
+package com.offhome.app.common
+
+import android.content.Context
+import android.content.SharedPreferences
+
+class SharedPreferenceManager {
+
+    companion object Factory {
+        private val appSettingsFile ="APP_SETTINGS"
+        private fun getSharedPreferences(): SharedPreferences {
+            return MyApp.getInstance().getSharedPreferences(
+                appSettingsFile,
+                Context.MODE_PRIVATE
+            )
+        }
+        fun setStringValue(dataLabel: String, dataValue: String) {
+            val editor = getSharedPreferences().edit()
+            editor.putString(dataLabel, dataValue)
+            editor.apply()
+        }
+        fun setStringValue(dataLabel: String, dataValue: Boolean) {
+            val editor = getSharedPreferences().edit()
+            editor.putBoolean(dataLabel, dataValue)
+            editor.apply()
+        }
+        fun getStringValue(dataLabel: String): String? {
+            return getSharedPreferences().getString(dataLabel, null)
+        }
+        fun getBooleanValue(dataLabel: String): Boolean {
+            return getSharedPreferences().getBoolean(dataLabel, false)
+        }
+    }
+}

--- a/app/src/main/java/com/offhome/app/common/SharedPreferenceManager.kt
+++ b/app/src/main/java/com/offhome/app/common/SharedPreferenceManager.kt
@@ -23,8 +23,8 @@ class SharedPreferenceManager {
             editor.putBoolean(dataLabel, dataValue)
             editor.apply()
         }
-        fun getStringValue(dataLabel: String): String? {
-            return getSharedPreferences().getString(dataLabel, null)
+        fun getStringValue(dataLabel: String): String {
+            return getSharedPreferences().getString(dataLabel, null).toString()
         }
         fun getBooleanValue(dataLabel: String): Boolean {
             return getSharedPreferences().getBoolean(dataLabel, false)

--- a/app/src/main/java/com/offhome/app/common/SharedPreferenceManager.kt
+++ b/app/src/main/java/com/offhome/app/common/SharedPreferenceManager.kt
@@ -18,7 +18,7 @@ class SharedPreferenceManager {
             editor.putString(dataLabel, dataValue)
             editor.apply()
         }
-        fun setStringValue(dataLabel: String, dataValue: Boolean) {
+        fun setBooleanValue(dataLabel: String, dataValue: Boolean) {
             val editor = getSharedPreferences().edit()
             editor.putBoolean(dataLabel, dataValue)
             editor.apply()
@@ -28,6 +28,9 @@ class SharedPreferenceManager {
         }
         fun getBooleanValue(dataLabel: String): Boolean {
             return getSharedPreferences().getBoolean(dataLabel, false)
+        }
+        fun deleteData() {
+            getSharedPreferences().edit().clear().apply()
         }
     }
 }

--- a/app/src/main/java/com/offhome/app/ui/infoactivity/InfoActivityViewModel.kt
+++ b/app/src/main/java/com/offhome/app/ui/infoactivity/InfoActivityViewModel.kt
@@ -20,6 +20,8 @@ class InfoActivityViewModel : ViewModel() {
      * @return the result with a live data string type
      */
     fun joinActivity(usuariCreador: String, dataHoraIni: String): MutableLiveData<String> {
-        return repository.joinActivity(usuariCreador, dataHoraIni, SharedPreferenceManager.getStringValue(Constants().PREF_EMAIL))
+        return repository.joinActivity(usuariCreador, dataHoraIni,
+            SharedPreferenceManager.getStringValue(Constants().PREF_EMAIL).toString()
+        )
     }
 }

--- a/app/src/main/java/com/offhome/app/ui/infoactivity/InfoActivityViewModel.kt
+++ b/app/src/main/java/com/offhome/app/ui/infoactivity/InfoActivityViewModel.kt
@@ -2,6 +2,8 @@ package com.offhome.app.ui.infoactivity
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.offhome.app.common.Constants
+import com.offhome.app.common.SharedPreferenceManager
 import com.offhome.app.data.ActivitiesRepository
 
 /**
@@ -15,10 +17,9 @@ class InfoActivityViewModel : ViewModel() {
      * This function calls the [ActivitiesRepository] in order to join to an activity
      * @param usuariCreador is the creator of the activity
      * @param dataHoraIni is the date and hour of the activity
-     * @param usuariParticipant is the user that wants to join the activity
      * @return the result with a live data string type
      */
-    fun joinActivity(usuariCreador: String, dataHoraIni: String, usuariParticipant: String): MutableLiveData<String> {
-        return repository.joinActivity(usuariCreador, dataHoraIni, usuariParticipant)
+    fun joinActivity(usuariCreador: String, dataHoraIni: String): MutableLiveData<String> {
+        return repository.joinActivity(usuariCreador, dataHoraIni, SharedPreferenceManager.getStringValue(Constants().PREF_EMAIL))
     }
 }

--- a/app/src/main/java/com/offhome/app/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/offhome/app/ui/login/LoginActivity.kt
@@ -129,7 +129,7 @@ class LoginActivity : AppCompatActivity() {
                             this
                         )
                         SharedPreferenceManager.setStringValue(Constants().PREF_EMAIL, account.email.toString())
-                        SharedPreferenceManager.setStringValue(Constants().PREF_PROVIDER, "google")
+                        SharedPreferenceManager.setStringValue(Constants().PREF_PROVIDER, Constants().PREF_PROVIDER_GOOGLE)
                         val welcome = getString(R.string.welcome)
                         val intent = Intent(this, MainActivity::class.java)
                         startActivity(intent)

--- a/app/src/main/java/com/offhome/app/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/offhome/app/ui/login/LoginActivity.kt
@@ -22,6 +22,8 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.GoogleAuthProvider
 import com.offhome.app.MainActivity
 import com.offhome.app.R
+import com.offhome.app.common.Constants
+import com.offhome.app.common.SharedPreferenceManager
 import com.offhome.app.ui.recoverPassword.RecoverPasswordActivity
 import com.offhome.app.ui.signup.SignUpActivity
 import com.offhome.app.ui.signup.SignUpViewModel
@@ -62,6 +64,13 @@ class LoginActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_login)
+
+        if (SharedPreferenceManager.getStringValue(Constants().PREF_EMAIL) != null) {
+            val intent = Intent(this, MainActivity::class.java)
+            startActivity(intent)
+            finish()
+        }
+
         setUp()
         startObservers()
         editTextsChanges()
@@ -119,7 +128,18 @@ class LoginActivity : AppCompatActivity() {
                             null,
                             this
                         )
-                        // updateUiWithUser(LoggedInUserView())
+                        SharedPreferenceManager.setStringValue(Constants().PREF_EMAIL, account.email.toString())
+                        SharedPreferenceManager.setStringValue(Constants().PREF_PROVIDER, "google")
+                        val welcome = getString(R.string.welcome)
+                        val intent = Intent(this, MainActivity::class.java)
+                        startActivity(intent)
+                        Toast.makeText(
+                            applicationContext,
+                            "$welcome ${account.email}",
+                            Toast.LENGTH_LONG
+                        ).show()
+                        finish()
+
                     } else {
                         Log.w("LOGIN", "signInWithEmail:failure", it.exception)
                         Toast.makeText(

--- a/app/src/main/java/com/offhome/app/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/offhome/app/ui/login/LoginViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.offhome.app.R
+import com.offhome.app.common.Constants
+import com.offhome.app.common.SharedPreferenceManager
 import com.offhome.app.data.LoginRepository
 import com.offhome.app.data.Result
 
@@ -29,13 +31,15 @@ class LoginViewModel(private val loginRepository: LoginRepository) : ViewModel()
     /**
      * It calls te repository to login and treats the result to set the mutable live data of the result of the login
      */
-    fun login(username: String, password: String) {
+    fun login(email: String, password: String) {
         // can be launched in a separate asynchronous job
-        val result = loginRepository.login(username, password)
+        val result = loginRepository.login(email, password)
 
         if (result is Result.Success) {
             _loginResult.value =
                 LoginResult(success = LoggedInUserView(data = result.data))
+            SharedPreferenceManager.setStringValue(Constants().PREF_EMAIL, email)
+            SharedPreferenceManager.setStringValue(Constants().PREF_PROVIDER, "password")
         } else {
             if (result is Result.Error) {
                 _loginResult.value = LoginResult(error = R.string.login_failed)

--- a/app/src/main/java/com/offhome/app/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/offhome/app/ui/login/LoginViewModel.kt
@@ -39,7 +39,7 @@ class LoginViewModel(private val loginRepository: LoginRepository) : ViewModel()
             _loginResult.value =
                 LoginResult(success = LoggedInUserView(data = result.data))
             SharedPreferenceManager.setStringValue(Constants().PREF_EMAIL, email)
-            SharedPreferenceManager.setStringValue(Constants().PREF_PROVIDER, "password")
+            SharedPreferenceManager.setStringValue(Constants().PREF_PROVIDER, Constants().PREF_PROVIDER_PASSWORD)
         } else {
             if (result is Result.Error) {
                 _loginResult.value = LoginResult(error = R.string.login_failed)

--- a/app/src/main/java/com/offhome/app/ui/otherprofile/OtherProfileViewModel.kt
+++ b/app/src/main/java/com/offhome/app/ui/otherprofile/OtherProfileViewModel.kt
@@ -3,6 +3,8 @@ package com.offhome.app.ui.otherprofile
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.offhome.app.common.Constants
+import com.offhome.app.common.SharedPreferenceManager
 import com.offhome.app.data.model.FollowingUser
 import com.offhome.app.model.profile.ProfileRepository
 import com.offhome.app.model.profile.TagData
@@ -28,6 +30,7 @@ class OtherProfileViewModel : ViewModel() {
     lateinit var isFollowing: MutableLiveData<Boolean>
     lateinit var followResult: MutableLiveData<Boolean>
     private var repository = ProfileRepository()
+    private val currentUser = SharedPreferenceManager.getStringValue(Constants().PREF_EMAIL)
 
     /**
      * It sets de info to the user
@@ -58,7 +61,6 @@ class OtherProfileViewModel : ViewModel() {
      * It calls the repository to get if one user follows the other
      */
     fun isFollowing(): List<FollowingUser>? {
-        val currentUser = "currentUser"
         listFollowing = repository.following(currentUser) as MutableLiveData<List<FollowingUser>>
         return listFollowing.value
     }
@@ -67,7 +69,6 @@ class OtherProfileViewModel : ViewModel() {
      * It calls the repository to start following a new user
      */
     fun follow() {
-        val currentUser = "currentUser"
         followResult.value = repository.follow(currentUser, userInfo.email).value == "OK"
         isFollowing.value = true
         userInfo.followers += 1
@@ -77,7 +78,6 @@ class OtherProfileViewModel : ViewModel() {
      * It calls the repository to stop following a user
      */
     fun stopFollowing() {
-        val currentUser = "currentUser"
         followResult.value = repository.stopFollowing(currentUser, userInfo.email).value == "OK"
         isFollowing.value = false
         userInfo.followers -= 1

--- a/app/src/main/java/com/offhome/app/ui/otherprofile/OtherProfileViewModel.kt
+++ b/app/src/main/java/com/offhome/app/ui/otherprofile/OtherProfileViewModel.kt
@@ -30,7 +30,7 @@ class OtherProfileViewModel : ViewModel() {
     lateinit var isFollowing: MutableLiveData<Boolean>
     lateinit var followResult: MutableLiveData<Boolean>
     private var repository = ProfileRepository()
-    private val currentUser = SharedPreferenceManager.getStringValue(Constants().PREF_EMAIL)
+    private val currentUser = SharedPreferenceManager.getStringValue(Constants().PREF_EMAIL).toString()
 
     /**
      * It sets de info to the user

--- a/app/src/main/java/com/offhome/app/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/offhome/app/ui/profile/ProfileFragment.kt
@@ -22,6 +22,7 @@ import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
 import com.google.gson.GsonBuilder
 import com.offhome.app.R
+import com.offhome.app.common.SharedPreferenceManager
 import com.offhome.app.ui.login.LoginActivity
 import com.offhome.app.ui.otherprofile.OtherProfileActivity
 
@@ -321,6 +322,7 @@ class ProfileFragment : Fragment() {
             logout_dialog.setMessage(R.string.dialog_logout_message)
             logout_dialog.setPositiveButton(R.string.ok) { dialog, id ->
                 firebaseAuth.signOut()
+                SharedPreferenceManager.deleteData()
                 requireActivity().run {
                     startActivity(Intent(this, LoginActivity::class.java))
                     finish()

--- a/app/src/main/java/com/offhome/app/ui/profile/ProfileFragmentViewModel.kt
+++ b/app/src/main/java/com/offhome/app/ui/profile/ProfileFragmentViewModel.kt
@@ -36,7 +36,7 @@ import com.offhome.app.model.profile.UserInfo
 class ProfileFragmentViewModel : ViewModel() {
 
     private var repository = ProfileRepository()
-    private var loggedUserEmail = SharedPreferenceManager.getStringValue(Constants().PREF_EMAIL)
+    private var loggedUserEmail = SharedPreferenceManager.getStringValue(Constants().PREF_EMAIL).toString()
 
     private var _profileInfo = MutableLiveData<UserInfo>()
     var profileInfo: LiveData<UserInfo> = _profileInfo

--- a/app/src/main/java/com/offhome/app/ui/profile/ProfileFragmentViewModel.kt
+++ b/app/src/main/java/com/offhome/app/ui/profile/ProfileFragmentViewModel.kt
@@ -4,6 +4,8 @@ import android.text.Editable
 import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.*
+import com.offhome.app.common.Constants
+import com.offhome.app.common.SharedPreferenceManager
 import com.offhome.app.model.ActivityFromList
 import com.offhome.app.model.profile.ProfileRepository
 import com.offhome.app.model.profile.TagData
@@ -34,7 +36,7 @@ import com.offhome.app.model.profile.UserInfo
 class ProfileFragmentViewModel : ViewModel() {
 
     private var repository = ProfileRepository()
-    private var loggedUserEmail = "victorfer@gmai.com" // stub
+    private var loggedUserEmail = SharedPreferenceManager.getStringValue(Constants().PREF_EMAIL)
 
     private var _profileInfo = MutableLiveData<UserInfo>()
     var profileInfo: LiveData<UserInfo> = _profileInfo

--- a/app/src/main/java/com/offhome/app/ui/profile/ProfilePlaceholderFragment.kt
+++ b/app/src/main/java/com/offhome/app/ui/profile/ProfilePlaceholderFragment.kt
@@ -6,8 +6,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.offhome.app.R
+import com.offhome.app.common.Constants
+import com.offhome.app.common.SharedPreferenceManager
 import com.offhome.app.ui.updatePassword.UpdatePasswordActivity
 
 /**
@@ -33,10 +36,13 @@ class ProfilePlaceholderFragment : Fragment() {
         val btnChangePwd = view.findViewById<Button>(R.id.changePassword)
 
         btnChangePwd.setOnClickListener {
-            requireActivity().run {
-                startActivity(Intent(this, UpdatePasswordActivity::class.java))
-                finish()
-            }
+            if (SharedPreferenceManager.getStringValue(Constants().PREF_PROVIDER) == Constants().PREF_PROVIDER_PASSWORD)
+                requireActivity().run {
+                    startActivity(Intent(this, UpdatePasswordActivity::class.java))
+                    finish()
+                }
+            else
+                Toast.makeText(context, getString(R.string.error_change_password_google), Toast.LENGTH_LONG).show()
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -201,4 +201,5 @@
     <string name="couldnt_add_tag_toast">Couldn\'t add tag</string>
     <string name="tag_deleted_toast">Tag deleted</string>
     <string name="couldnt_delete_tag_toast">Couldn\'t delete tag</string>
+    <string name="error_change_password_google">You can\'t change the password, because you have logged in with Google</string>
 </resources>


### PR DESCRIPTION
He creat tres classes noves al directori common:
- SharedPreferenceManager: Guarda i obté les dades que guardem a dispositiu, es a dir email de l'usuari loggejat i el providesr, és a dir si ha iniciat sessió amb contrasenya o amb google. Aixo es necessari, per exemple, si es vol fer update de la contrasenya nomes et deixi si no has fer login amb Google (també està fet ja)
- Constants: Estan algunes constants per al SharedPreferenceManager i també el base url del backend. S'hauria des de tots els clients, accedir a aquesta constant, en comptes de posar sempre la base url
- MyApp. Aquesta classe conté el context de l'app i d'aquesta manera es pot obtenir el context des de qualsevol classe del nostre sistema sense haver d'anar passant el context per les crides

En **teoria**, he canviat tots els stubs de current user per l'acces al SharedPreference, per tant s'hauria de fer amb el usuari loggejat sempre. Tot i aixo s'hauria de revisar